### PR TITLE
Home hero card: cover art, overview, story-wide scoping

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,13 @@ time the version bump renames that section to the new version and date.
 
 ## [Unreleased]
 
+### Added
+- **Cover art and overview on Home.** Selecting a project on Home now opens a hero card above the scene list. Attach **cover art** — upload an image (copied into the project's folder) or pick one already in your vault — and see the **logline**, **theme**, and **word-count target** at a glance, with a progress bar tracking words toward the target. Logline, theme, and target are editable inline and share the same data as Plan → Overview, so there's no second copy to keep in sync.
+
+### Changed
+- **The idea inbox now appears only on the all-projects view.** The quick-capture idea inbox used to sit at the top of Home even after you'd drilled into a single project, mixing a global list with project-scoped content. It now shows only on the all-projects Home (and when you have no projects yet); the focused-project view shows just that project. Story ideas are cross-project seeds, so they're captured from the top-level view.
+- **Overview and goals are shared across a story's drafts.** Cover art, logline, theme, genre, audience, and the word target describe the *book*, not one draft — so they're now stored once per story and shared by every draft instead of drifting per-draft. Edit them from any draft (the Home hero or Plan → Overview) and every draft reflects the change. Track → Targets now lists each story once instead of once per draft.
+
 ## [1.4.0] - 2026-07-01
 
 ### Added

--- a/SCHEMA.md
+++ b/SCHEMA.md
@@ -80,10 +80,12 @@ A single nested object under `inkswell`. All sub-keys optional. Source: `src/pro
 `sceneSteps` / `manuscriptSteps` (ordered `{id, options}` step lists) · `separator` (string) · `targetBasename` (string, default `manuscript`) · `format` (`md` · `html` · `pandoc`) · `pandoc` (`{to, extension, extraArgs}`, when `format: pandoc`).
 
 ### `inkswell.goals` — targets & pace
-`target` (number) · `deadline` (string `YYYY-MM-DD`) · `daysPerWeek` (number 1–7, default 7).
+`target` (number) · `deadline` (string `YYYY-MM-DD`) · `daysPerWeek` (number 1–7, default 7). **Story-level** — see the note under `overview`.
 
 ### `inkswell.overview` — novel-level planning (Plan → Overview)
-Short, single-line planning fields: `logline` · `theme` · `genre` · `audience` (all strings) · `planningNote` (string, vault path). Long-form planning prose does **not** live in frontmatter — it lives in the **planning note** (see below), and `planningNote` records that note's path once created.
+Short, single-line planning fields: `logline` · `theme` · `genre` · `audience` (all strings) · `planningNote` (string, vault path) · `cover` (string, vault path to the cover image). Long-form planning prose does **not** live in frontmatter — it lives in the **planning note** (see below), and `planningNote` records that note's path once created. `cover` is shown on the Home focused-project hero card; an uploaded cover is copied into the project folder as `cover.<ext>`, a picked image is referenced in place.
+
+**Story-level, not per-draft:** `overview` and `goals` describe the *book*, so they're shared across all drafts of a story. They are read from and written to the story's **base draft** (the draft whose folder is an ancestor of its siblings — the copy origin), regardless of which draft is focused. A byte-copied new draft may carry an inherited stale copy in its own frontmatter; it's inert (never read) unless the base draft is deleted, in which case the next base's copy is used.
 
 **The planning note** is an ordinary vault note (default `"<Title> — Plan.md"`, sibling of the index) holding the synopsis and outline prose under stable app-managed H2 sections: `## Synopsis` · `## Plot groundwork` · `## Act I` · `## Act II` · `## Act III`. It carries **no** `longform` key (so the store never mistakes it for a project) and is prose-only — outside this frontmatter contract, but listed here because `overview.planningNote` points at it. Source: `src/plan/planning-note.ts`, `src/plan/overview-panel.ts`.
 

--- a/src/plan/overview-panel.ts
+++ b/src/plan/overview-panel.ts
@@ -13,6 +13,7 @@ import { App, TFile } from "obsidian";
 import { ActiveProject, resolveActive } from "../projects/active-project";
 import { persistOverview } from "../projects/index-writer";
 import { ProjectStore } from "../projects/project-store";
+import { baseDraftFor } from "../projects/stories";
 import { Project, ProjectOverview } from "../projects/types";
 import { openScene } from "../scenes/scene-actions";
 import {
@@ -60,11 +61,14 @@ export class OverviewPanel {
     container.empty();
     container.addClass("inkswell-overview");
 
-    const project = resolveActive(this.store.getProjects(), this.active.get());
-    if (!project) {
+    const active = resolveActive(this.store.getProjects(), this.active.get());
+    if (!active) {
       container.createDiv({ cls: "inkswell-stats__muted", text: "No projects found." });
       return;
     }
+    // Overview + planning note are story-level — always read/write the base draft
+    // so all drafts of a story share them (matches the Home hero card).
+    const project = baseDraftFor(this.store.getProjects(), active);
 
     this.renderFields(container, project);
     this.renderProse(container, project);

--- a/src/projects/cover.ts
+++ b/src/projects/cover.ts
@@ -1,0 +1,118 @@
+/**
+ * Cover-art file handling for a project. Two ways to set a cover, both ending in
+ * a single `inkswell.overview.cover` vault path:
+ *   - Upload: copy an external image into the project folder as `cover.<ext>`.
+ *   - Pick existing: reference an image already in the vault, in place (no copy).
+ *
+ * All image concerns live here so the explorer view stays a view. Cleanup only
+ * ever deletes a cover file *we* created (project folder, named `cover.*`) — a
+ * referenced vault image is never touched, only repointed.
+ */
+
+import { App, FuzzySuggestModal, TFile } from "obsidian";
+import { Project } from "./types";
+
+export const IMAGE_EXTENSIONS = ["png", "jpg", "jpeg", "gif", "webp", "avif", "bmp", "svg"];
+
+function isImage(file: TFile): boolean {
+  return IMAGE_EXTENSIONS.includes(file.extension.toLowerCase());
+}
+
+/** Resolve a stored cover path to a displayable `app://…?<mtime>` URL, or null if missing. */
+export function resolveCoverSrc(app: App, path: string | undefined): string | null {
+  if (!path) return null;
+  const file = app.vault.getAbstractFileByPath(path);
+  return file instanceof TFile ? app.vault.getResourcePath(file) : null;
+}
+
+/** The project's folder = the index note's parent (vault root → ""). */
+function projectFolder(project: Project): string {
+  const slash = project.vaultPath.lastIndexOf("/");
+  return slash === -1 ? "" : project.vaultPath.slice(0, slash);
+}
+
+/** True if `path` is a cover file we created (in the project folder, named `cover.*`). */
+function isOwnedCover(project: Project, path: string | undefined): boolean {
+  if (!path) return false;
+  const folder = projectFolder(project);
+  const prefix = folder ? `${folder}/cover.` : "cover.";
+  return path.startsWith(prefix);
+}
+
+function extensionFor(file: File): string {
+  const dot = file.name.lastIndexOf(".");
+  const ext = dot >= 0 ? file.name.slice(dot + 1).toLowerCase() : "";
+  if (IMAGE_EXTENSIONS.includes(ext)) return ext;
+  // Fall back to the MIME subtype (e.g. image/png → png), else png.
+  const sub = file.type.split("/")[1]?.toLowerCase();
+  return sub && IMAGE_EXTENSIONS.includes(sub) ? sub : "png";
+}
+
+/**
+ * Copy an uploaded image into the project folder as `cover.<ext>` and return its
+ * vault path. Replaces an existing same-path file in place; if a previous owned
+ * cover had a different extension, it's removed first so we don't orphan it.
+ */
+export async function setCoverFromUpload(app: App, project: Project, file: File): Promise<string> {
+  const folder = projectFolder(project);
+  const path = folder ? `${folder}/cover.${extensionFor(file)}` : `cover.${extensionFor(file)}`;
+
+  const prev = project.inkswell?.overview?.cover;
+  if (isOwnedCover(project, prev) && prev !== path) await removeCoverFile(app, prev);
+
+  const data = await file.arrayBuffer();
+  const existing = app.vault.getAbstractFileByPath(path);
+  if (existing instanceof TFile) await app.vault.modifyBinary(existing, data);
+  else await app.vault.createBinary(path, data);
+  return path;
+}
+
+/** Delete a cover file by path (silently ignores a missing/non-file path). */
+export async function removeCoverFile(app: App, path: string | undefined): Promise<void> {
+  if (!path) return;
+  const file = app.vault.getAbstractFileByPath(path);
+  if (file instanceof TFile) await app.vault.delete(file);
+}
+
+/** If the project owns its current cover file, delete it. Called on remove/replace. */
+export async function cleanupOwnedCover(app: App, project: Project): Promise<void> {
+  const prev = project.inkswell?.overview?.cover;
+  if (isOwnedCover(project, prev)) await removeCoverFile(app, prev);
+}
+
+/** Fuzzy-pick an image already in the vault. Resolves with the file, or null if dismissed. */
+export function pickVaultImage(app: App): Promise<TFile | null> {
+  return new Promise((resolve) => {
+    const modal = new ImageSuggestModal(app, resolve);
+    modal.open();
+  });
+}
+
+class ImageSuggestModal extends FuzzySuggestModal<TFile> {
+  private onChoose: (file: TFile | null) => void;
+  private resolved = false;
+
+  constructor(app: App, onChoose: (file: TFile | null) => void) {
+    super(app);
+    this.onChoose = onChoose;
+    this.setPlaceholder("Choose a cover image from the vault…");
+  }
+
+  getItems(): TFile[] {
+    return this.app.vault.getFiles().filter(isImage);
+  }
+
+  getItemText(file: TFile): string {
+    return file.path;
+  }
+
+  onChooseItem(file: TFile): void {
+    this.resolved = true;
+    this.onChoose(file);
+  }
+
+  onClose(): void {
+    super.onClose();
+    if (!this.resolved) this.onChoose(null);
+  }
+}

--- a/src/projects/stories.ts
+++ b/src/projects/stories.ts
@@ -49,3 +49,37 @@ export function storyOf(stories: Story[], activePath: string | null): Story | nu
   if (!activePath) return null;
   return stories.find((s) => s.drafts.some((d) => d.vaultPath === activePath)) ?? null;
 }
+
+/** Dirname of a draft's index path ("" for vault root). */
+function draftFolder(p: Project): string {
+  const i = p.vaultPath.lastIndexOf("/");
+  return i === -1 ? "" : p.vaultPath.slice(0, i);
+}
+
+/** True if folder `a` is an ancestor of (or equal to) folder `b`. */
+function isAncestorFolder(a: string, b: string): boolean {
+  return a === "" || a === b || b.startsWith(`${a}/`);
+}
+
+/**
+ * A story's *base draft* — the single source of truth for story-level metadata
+ * (cover, overview, goals) that every draft should share. New drafts are copied
+ * into a `Drafts/` subfolder of their source, so the original draft's folder is
+ * an ancestor of every sibling; that draft is the base. Falls back to the first
+ * draft when no single ancestor exists (e.g. drafts manually moved apart).
+ */
+export function baseDraft(story: Story): Project {
+  for (const cand of story.drafts) {
+    const cf = draftFolder(cand);
+    if (story.drafts.every((d) => isAncestorFolder(cf, draftFolder(d)))) return cand;
+  }
+  return story.drafts[0];
+}
+
+/** The base draft of the story containing `project` (or `project` itself if ungrouped). */
+export function baseDraftFor(projects: Project[], project: Project): Project {
+  const story = groupIntoStories(projects).find((s) =>
+    s.drafts.some((d) => d.vaultPath === project.vaultPath)
+  );
+  return story ? baseDraft(story) : project;
+}

--- a/src/projects/types.ts
+++ b/src/projects/types.ts
@@ -98,6 +98,8 @@ export interface ProjectOverview {
   audience?: string;
   /** Vault path of the project's planning note, set lazily on first prose save. */
   planningNote?: string;
+  /** Vault path of the cover image. Uploads copy into the project folder; picked images are referenced in place. */
+  cover?: string;
 }
 
 /** Series membership for a book (project). A series is the set of books sharing a `name`. */

--- a/src/stats/stats-view.ts
+++ b/src/stats/stats-view.ts
@@ -27,7 +27,7 @@ import { formatReadTime, heatLevel } from "./format";
 import { resolveActive } from "../projects/active-project";
 import { ProjectStats } from "../projects/project-stats";
 import { ProjectStore } from "../projects/project-store";
-import { draftLabel, groupIntoStories, storyOf } from "../projects/stories";
+import { baseDraft, draftLabel, groupIntoStories, storyOf } from "../projects/stories";
 import { Project, isMultiScene } from "../projects/types";
 import { SCENE_STATUSES, readSceneMeta, statusLabel } from "../scenes/scene-meta";
 import { sprintSeconds, sprintStats, sprintWpm } from "../sprints/sprint-stats";
@@ -451,8 +451,10 @@ export class StatsPanel {
   }
 
   private renderTargets(body: HTMLElement, daily: Record<string, number>): void {
-    const withTargets = this.store
-      .getProjects()
+    // Targets are story-level: one row per story, read off its base draft (not
+    // one row per draft, which would duplicate the shared goal).
+    const withTargets = groupIntoStories(this.store.getProjects())
+      .map((s) => baseDraft(s))
       .filter((p) => p.inkswell?.goals?.target && p.inkswell.goals.target > 0);
     if (withTargets.length === 0) {
       body.createDiv({

--- a/src/views/explorer/explorer-view.ts
+++ b/src/views/explorer/explorer-view.ts
@@ -7,10 +7,12 @@
  * note's frontmatter — never a scene body.
  */
 
-import { App, Menu, TFile } from "obsidian";
+import { App, Menu, Notice, TFile } from "obsidian";
 import { attachRowMenu } from "../../lib/row-menu";
 import { renameSceneInBeats } from "../../outliner/beats";
-import { persistDraft, persistInkswellData, updateScenes, writeSeries } from "../../projects/index-writer";
+import { cleanupOwnedCover, pickVaultImage, resolveCoverSrc, setCoverFromUpload } from "../../projects/cover";
+import { persistDraft, persistInkswellData, persistOverview, updateScenes, writeSeries } from "../../projects/index-writer";
+import { TargetModal } from "../../goals/target-modal";
 import { ProjectStats } from "../../projects/project-stats";
 import { ProjectStore } from "../../projects/project-store";
 import { reconcileSuggestions } from "../../projects/rename-heal";
@@ -22,7 +24,7 @@ import {
   unindentScene,
 } from "../../projects/scene-tree";
 import { Project, isMultiScene } from "../../projects/types";
-import { groupIntoStories } from "../../projects/stories";
+import { baseDraftFor, groupIntoStories } from "../../projects/stories";
 import { Series, groupIntoSeries, projectSeries } from "../../series/series";
 import { deleteScene, editSynopsis, promptText, renameScene } from "../../scenes/scene-actions";
 import { promptNewScene } from "../../outliner/create-scene";
@@ -85,10 +87,10 @@ export class ExplorerPanel {
     const newBtn = toolbar.createEl("button", { cls: "mod-cta", text: "New project" });
     newBtn.onclick = () => this.plugin.newProject();
 
-    this.renderIdeas(container);
-
     const projects = this.store.getProjects();
     if (projects.length === 0) {
+      // No projects yet — this is the global Home, so the idea inbox belongs here.
+      this.renderIdeas(container);
       container.createDiv({
         cls: "inkswell-explorer__empty",
         text: 'No writing projects yet. Click "New project" above to create one (or add a `longform` key to a note\'s frontmatter).',
@@ -116,6 +118,7 @@ export class ExplorerPanel {
       : null;
 
     if (focused) {
+      this.renderProjectHero(container, focused);
       const bar = container.createDiv({ cls: "inkswell-explorer__focus" });
       const back = bar.createEl("button", {
         cls: "inkswell-explorer__showall",
@@ -130,6 +133,9 @@ export class ExplorerPanel {
       return;
     }
 
+    // Unfocused = the global "all projects" dashboard: the idea inbox (a store of
+    // cross-project story seeds) lives here, not inside a focused project's view.
+    this.renderIdeas(container);
     for (const s of series) this.renderSeries(container, s);
     for (const project of standalone) this.renderProject(container, project);
   }
@@ -150,9 +156,11 @@ export class ExplorerPanel {
   private async renderSeriesTotals(el: HTMLElement, series: Series): Promise<void> {
     let words = 0;
     let target = 0;
+    const all = this.store.getProjects();
     for (const book of series.books) {
       words += await this.stats.projectWords(book);
-      const t = book.inkswell?.goals?.target;
+      // Target is story-level — read it off the book's base draft.
+      const t = baseDraftFor(all, book).inkswell?.goals?.target;
       if (typeof t === "number" && t > 0) target += t;
     }
     const books = series.books.length;
@@ -192,6 +200,153 @@ export class ExplorerPanel {
       del.setAttribute("aria-label", "Delete idea");
       del.onclick = () => this.plugin.removeIdea(idea.id);
     }
+  }
+
+  /**
+   * Focused-view hero card: cover art + at-a-glance logline / theme / target.
+   * Only rendered for the single focused project (never in the multi-project
+   * list). Fields autosave on `change` (blur) — the host's focus-guard prevents a
+   * mid-keystroke rebuild, matching the Plan → Overview convention.
+   */
+  private renderProjectHero(parent: HTMLElement, focused: Project): void {
+    // Story-level metadata (cover, overview, goals) lives on the story's base
+    // draft, so every draft shares one cover/logline/theme/target. Word-count
+    // progress, though, is the *focused* draft's own (each draft has its scenes).
+    const base = baseDraftFor(this.store.getProjects(), focused);
+    const hero = parent.createDiv({ cls: "inkswell-hero" });
+    const overview = base.inkswell?.overview ?? {};
+    const indexFile = this.indexFile(base);
+    const saveOverview = (patch: Partial<typeof overview>) => {
+      if (indexFile) void persistOverview(this.app, indexFile, patch);
+    };
+
+    // Cover: image when set, else a dashed placeholder. Both open the same menu.
+    const cover = hero.createDiv({ cls: "inkswell-hero__cover" });
+    const src = resolveCoverSrc(this.app, overview.cover);
+    if (src) {
+      const img = cover.createEl("img", { cls: "inkswell-hero__img" });
+      img.src = src;
+      img.alt = `${focused.draft.title} cover`;
+    } else {
+      cover.addClass("is-empty");
+      cover.createSpan({ cls: "inkswell-hero__placeholder", text: "+ Add cover" });
+    }
+    cover.setAttribute("aria-label", "Set cover image");
+    cover.onclick = (e) => this.coverMenu(base, !!src).showAtMouseEvent(e);
+
+    // Meta column: title, logline, theme, target/progress.
+    const meta = hero.createDiv({ cls: "inkswell-hero__meta" });
+    meta.createDiv({ cls: "inkswell-hero__title", text: focused.draft.title });
+
+    const field = (label: string, value: string | undefined, placeholder: string, save: (v: string) => void) => {
+      const row = meta.createDiv({ cls: "inkswell-hero__field" });
+      row.createDiv({ cls: "inkswell-hero__label", text: label });
+      const input = row.createEl("input", { type: "text", cls: "inkswell-hero__input" });
+      input.value = value ?? "";
+      input.placeholder = placeholder;
+      input.onchange = () => save(input.value.trim());
+    };
+    field("Logline", overview.logline, "One sentence: who wants what, against what odds…", (v) =>
+      saveOverview({ logline: v })
+    );
+    field("Theme", overview.theme, "The deeper meaning / life lesson…", (v) => saveOverview({ theme: v }));
+
+    this.renderHeroTarget(meta, focused, base);
+  }
+
+  /**
+   * Inline word target + progress bar; `⋯` opens the full target modal
+   * (deadline/pace). The target is story-level (read/written on `base`); the
+   * progress words are the focused draft's own.
+   */
+  private renderHeroTarget(meta: HTMLElement, focused: Project, base: Project): void {
+    const goals = base.inkswell?.goals;
+    const target = typeof goals?.target === "number" && goals.target > 0 ? goals.target : 0;
+    const indexFile = this.indexFile(base);
+
+    const row = meta.createDiv({ cls: "inkswell-hero__field" });
+    row.createDiv({ cls: "inkswell-hero__label", text: "Target" });
+    const control = row.createDiv({ cls: "inkswell-hero__targetrow" });
+    const input = control.createEl("input", { type: "number", cls: "inkswell-hero__input inkswell-hero__targetinput" });
+    input.value = target ? String(target) : "";
+    input.placeholder = "e.g. 80000";
+    input.min = "0";
+    input.onchange = () => {
+      if (!indexFile) return;
+      const n = Math.floor(Number(input.value));
+      const val = Number.isFinite(n) && n > 0 ? n : undefined;
+      void persistInkswellData(this.app, indexFile, { goals: { ...base.inkswell?.goals, target: val } });
+    };
+    control.createSpan({ cls: "inkswell-hero__unit", text: "words" });
+    const more = control.createEl("button", { cls: "inkswell-hero__more", text: "⋯" });
+    more.setAttribute("aria-label", "Deadline & pace");
+    more.onclick = () => new TargetModal(this.app, base).open();
+
+    if (!this.plugin.settings.showWordCounts) return;
+    const bar = meta.createDiv({ cls: "inkswell-progress inkswell-hero__bar" });
+    const fill = bar.createDiv({ cls: "inkswell-progress__fill" });
+    const stat = meta.createDiv({ cls: "inkswell-hero__stat" });
+    void this.stats.projectWords(focused).then((w) => {
+      if (target > 0) {
+        const pct = Math.min(100, Math.round((w / target) * 100));
+        fill.style.width = `${pct}%`;
+        stat.setText(`${w.toLocaleString()} / ${target.toLocaleString()} words · ${pct}%`);
+      } else {
+        bar.hide();
+        stat.setText(`${w.toLocaleString()} words`);
+      }
+    });
+  }
+
+  /** Cover action menu: upload, pick from vault, and (when set) remove. */
+  private coverMenu(project: Project, hasCover: boolean): Menu {
+    const menu = new Menu();
+    menu.addItem((i) =>
+      i.setTitle("Upload…").setIcon("upload").onClick(() => this.uploadCover(project))
+    );
+    menu.addItem((i) =>
+      i.setTitle("Choose from vault…").setIcon("image").onClick(() => void this.chooseCover(project))
+    );
+    if (hasCover) {
+      menu.addSeparator();
+      menu.addItem((i) =>
+        i.setTitle("Remove cover").setIcon("trash").onClick(() => void this.removeCover(project))
+      );
+    }
+    return menu;
+  }
+
+  /** Open an OS file picker, copy the chosen image into the project folder, persist its path. */
+  private uploadCover(project: Project): void {
+    const input = createEl("input", { type: "file" });
+    input.accept = "image/*";
+    input.onchange = async () => {
+      const file = input.files?.[0];
+      if (!file) return;
+      const indexFile = this.indexFile(project);
+      if (!indexFile) return;
+      try {
+        const path = await setCoverFromUpload(this.app, project, file);
+        await persistOverview(this.app, indexFile, { cover: path });
+      } catch (e) {
+        console.error(e);
+        new Notice("Couldn't set the cover image.");
+      }
+    };
+    input.click();
+  }
+
+  private async chooseCover(project: Project): Promise<void> {
+    const file = await pickVaultImage(this.app);
+    if (!file) return;
+    const indexFile = this.indexFile(project);
+    if (indexFile) await persistOverview(this.app, indexFile, { cover: file.path });
+  }
+
+  private async removeCover(project: Project): Promise<void> {
+    await cleanupOwnedCover(this.app, project);
+    const indexFile = this.indexFile(project);
+    if (indexFile) await persistOverview(this.app, indexFile, { cover: "" });
   }
 
   private renderProject(parent: HTMLElement, project: Project): void {

--- a/styles.css
+++ b/styles.css
@@ -1266,6 +1266,93 @@
   text-align: center;
 }
 
+/* Focused-project hero card (Home): cover art + logline / theme / target */
+.inkswell-hero {
+  display: flex;
+  flex-wrap: wrap;
+  gap: var(--size-4-4);
+  padding: var(--size-4-2) 0 var(--size-4-4);
+  margin-bottom: var(--size-4-2);
+  border-bottom: 1px solid var(--background-modifier-border);
+}
+.inkswell-hero__cover {
+  flex: 0 0 auto;
+  width: 120px;
+  aspect-ratio: 2 / 3;
+  border-radius: var(--radius-m);
+  overflow: hidden;
+  cursor: pointer;
+  background-color: var(--background-secondary);
+}
+.inkswell-hero__cover.is-empty {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  border: 1px dashed var(--background-modifier-border);
+}
+.inkswell-hero__cover.is-empty:hover {
+  border-color: var(--interactive-accent);
+}
+.inkswell-hero__placeholder {
+  color: var(--text-muted);
+  font-size: var(--font-ui-small);
+}
+.inkswell-hero__img {
+  width: 100%;
+  height: 100%;
+  object-fit: cover;
+  display: block;
+}
+.inkswell-hero__meta {
+  flex: 1 1 260px;
+  min-width: 0;
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-4-2);
+}
+.inkswell-hero__title {
+  font-weight: var(--font-bold);
+  font-size: var(--font-ui-large);
+}
+.inkswell-hero__field {
+  display: flex;
+  flex-direction: column;
+  gap: var(--size-4-1);
+}
+.inkswell-hero__label {
+  font-size: var(--font-ui-smaller);
+  font-weight: var(--font-semibold);
+  color: var(--text-muted);
+}
+.inkswell-hero__input {
+  width: 100%;
+}
+.inkswell-hero__targetrow {
+  display: flex;
+  align-items: center;
+  gap: var(--size-4-2);
+}
+.inkswell-hero__targetinput {
+  width: 12ch;
+  flex: 0 0 auto;
+}
+.inkswell-hero__unit {
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+}
+.inkswell-hero__more {
+  margin-left: auto;
+  padding: 0 var(--size-4-2);
+}
+.inkswell-hero__bar {
+  margin-top: var(--size-4-1);
+}
+.inkswell-hero__stat {
+  color: var(--text-muted);
+  font-size: var(--font-ui-smaller);
+  font-variant-numeric: tabular-nums;
+}
+
 /* Series grouping (Home): header + nested book projects */
 .inkswell-series {
   margin-bottom: var(--size-4-4);

--- a/tests/stories.test.ts
+++ b/tests/stories.test.ts
@@ -1,5 +1,5 @@
 import { describe, expect, it } from "vitest";
-import { draftLabel, groupIntoStories, storyOf } from "../src/projects/stories";
+import { baseDraft, baseDraftFor, draftLabel, groupIntoStories, storyOf } from "../src/projects/stories";
 import { Project } from "../src/projects/types";
 
 function project(path: string, title: string, draftTitle: string | null = null): Project {
@@ -63,5 +63,49 @@ describe("storyOf", () => {
   it("returns null for a null or unknown path", () => {
     expect(storyOf(stories, null)).toBeNull();
     expect(storyOf(stories, "gone.md")).toBeNull();
+  });
+});
+
+describe("baseDraft", () => {
+  it("picks the draft whose folder is an ancestor of the others (the copy origin)", () => {
+    // New drafts are copied under <origin>/Drafts/<name>/, so the origin's
+    // folder is an ancestor of every sibling.
+    const origin = project("Book/Novel/Novel.md", "Novel", "Draft 1");
+    const editor = project("Book/Novel/Drafts/Editor/Novel — Editor.md", "Novel", "Editor");
+    const proof = project("Book/Novel/Drafts/Editor/Drafts/Proof/Novel — Proof.md", "Novel", "Proof");
+    // Order shouldn't matter — the ancestor wins regardless of position.
+    expect(baseDraft({ title: "Novel", drafts: [proof, editor, origin] }).vaultPath).toBe("Book/Novel/Novel.md");
+  });
+
+  it("returns the sole draft for a one-draft story", () => {
+    const solo = project("x/Solo.md", "Solo");
+    expect(baseDraft({ title: "Solo", drafts: [solo] })).toBe(solo);
+  });
+
+  it("falls back to the first draft when no folder is a common ancestor", () => {
+    const a = project("one/A.md", "Novel", "A");
+    const b = project("two/B.md", "Novel", "B");
+    expect(baseDraft({ title: "Novel", drafts: [a, b] })).toBe(a);
+  });
+
+  it("treats a vault-root draft as an ancestor of nested siblings", () => {
+    const root = project("Novel.md", "Novel", "Draft 1");
+    const nested = project("Drafts/Editor/Novel — Editor.md", "Novel", "Editor");
+    expect(baseDraft({ title: "Novel", drafts: [nested, root] }).vaultPath).toBe("Novel.md");
+  });
+});
+
+describe("baseDraftFor", () => {
+  const origin = project("Book/Novel/Novel.md", "Novel", "Draft 1");
+  const editor = project("Book/Novel/Drafts/Editor/Novel — Editor.md", "Novel", "Editor");
+  const other = project("z/Other.md", "Other");
+
+  it("resolves the base draft of the story containing the given draft", () => {
+    expect(baseDraftFor([origin, editor, other], editor).vaultPath).toBe("Book/Novel/Novel.md");
+  });
+
+  it("returns the project itself when it isn't in the list", () => {
+    const stray = project("gone/G.md", "Ghost");
+    expect(baseDraftFor([origin, editor], stray)).toBe(stray);
   });
 });


### PR DESCRIPTION
## Summary

Adds a **project hero card** to the Home focused view and fixes draft-scoping of story-level metadata.

- **Cover art + overview on Home** — selecting a project opens a hero card above the scene list: attach cover art (upload into the project folder, or pick an existing vault image), plus inline **logline**, **theme**, and a **word-target progress bar**. Logline/theme/target share the same data as Plan → Overview.
- **Idea inbox scoped to the all-projects view** — it no longer sits atop a focused project, mixing global capture with project-scoped content.
- **Overview + goals made story-level** — cover, logline, theme, genre, audience, and the word target describe the book, so they're now read/written via the story's **base draft** and shared by every draft instead of drifting per-draft. Track → Targets now lists each story once, not once per draft.

## Implementation notes

- New `src/projects/cover.ts` isolates all image handling (upload/copy, resolve via `getResourcePath`, owned-file cleanup, vault-image fuzzy picker).
- `baseDraft(story)` / `baseDraftFor(projects, project)` in `stories.ts` resolve the canonical draft (folder-ancestor of siblings, `drafts[0]` fallback); the Home hero, Plan → Overview panel, series totals, and Track → Targets all route reads/writes through it.
- Reuses existing persistence (`persistOverview`, the `TargetModal` goals read-merge) — no new storage keys except `overview.cover`.

## Testing

- `npm run build` clean; full suite **329/329** (7 new tests for `baseDraft`/`baseDraftFor`).
- Verified in the dev vault: hero renders on focus; cover upload/pick/remove; inline edits persist; and story-wide read/write confirmed across the 3-draft Mina Mora story (edit on a non-base draft lands on the base; a third draft reads the shared values).

## Known follow-ups (non-blocking)

- Stale inherited `overview`/`goals` copies on non-base drafts are inert but not stripped — left as a fallback rather than doing a destructive migration.
- Hero's phone layout is unverified on real hardware (CSS wraps; touch/file-picker untested).
- Version bump (1.4.0 → 1.5.0) not done in this PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)